### PR TITLE
Bring back support for original "end" keyword

### DIFF
--- a/examples/test.rap
+++ b/examples/test.rap
@@ -8,6 +8,10 @@ k := 1;
             output: "три";
         все;
         вывод: k;
-    все;
+    всё;
     k:= k + 1;
 кц по k > 10;
+
+if yes then
+   output: "four"
+done

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -131,6 +131,8 @@ Token Lexer::getNextToken()
 	checkKeyword(nextToken, "при", T_WHEN);
 	checkKeyword(nextToken, "while", T_WHILE);
 	checkKeyword(nextToken, "пока", T_WHILE);
+	checkKeyword(nextToken, "все", T_G_END);
+	checkKeyword(nextToken, "всё", T_G_END);
 
 	checkKeyword(nextToken, "yes", T_YES);
 	checkKeyword(nextToken, "да", T_YES);

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -133,6 +133,7 @@ Token Lexer::getNextToken()
 	checkKeyword(nextToken, "пока", T_WHILE);
 	checkKeyword(nextToken, "все", T_G_END);
 	checkKeyword(nextToken, "всё", T_G_END);
+	checkKeyword(nextToken, "done", T_G_END);
 
 	checkKeyword(nextToken, "yes", T_YES);
 	checkKeyword(nextToken, "да", T_YES);

--- a/parser.cpp
+++ b/parser.cpp
@@ -476,7 +476,7 @@ For* Parser::parseFor()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> stmts(new NodeList());
-	while(hasTokens() && peekToken().getType() != T_OD && peekToken().getType() != T_UNTIL)
+	while(hasTokens() && peekToken().getType() != T_OD && peekToken().getType() != T_UNTIL && peekToken().getType() != T_G_END)
 	{
 		stmts->pushNode(parseStatement());
 		parseSeparation();
@@ -488,7 +488,7 @@ For* Parser::parseFor()
 		getToken();
 		result->setUntilCondition(parseExpression());
 	}
-	else if(hasTokens() && peekToken().getType() == T_OD)
+	else if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
 		getToken();
 	else
 		throw ParserSyntaxException(getToken(), "Expected \"od\" or \"until\" command!");
@@ -908,14 +908,14 @@ Repeat* Parser::parseRepeat()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> stmts(new NodeList());
-	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL))
+	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL || peekToken().getType() == T_G_END))
 	{
 		stmts->pushNode(parseStatement());
 		parseSeparation();
 	}
 	result->setStatements(stmts.release());
 
-	if(hasTokens() && peekToken().getType() == T_OD)
+	if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
 		getToken();
 	else if(hasTokens() && peekToken().getType() == T_UNTIL)
 	{
@@ -1019,7 +1019,7 @@ While* Parser::parseWhile()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> whileStmts(new NodeList());
-	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL))
+	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL || peekToken().getType() == T_G_END))
 	{
 		whileStmts->pushNode(parseStatement());
 		parseSeparation();
@@ -1029,7 +1029,7 @@ While* Parser::parseWhile()
 	result->setLineNumber(tok.getLineNumber());
 	result->setColumnNumber(tok.getColumnNumber());
 
-	if(hasTokens() && peekToken().getType() == T_OD)
+	if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
 	{
 		getToken();
 		result->setCondition(cond.release());

--- a/parser.cpp
+++ b/parser.cpp
@@ -476,7 +476,7 @@ For* Parser::parseFor()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> stmts(new NodeList());
-	while(hasTokens() && peekToken().getType() != T_OD && peekToken().getType() != T_UNTIL && peekToken().getType() != T_G_END)
+	while(hasTokens() && peekToken().getType() != T_OD && peekToken().getType() != T_UNTIL)
 	{
 		stmts->pushNode(parseStatement());
 		parseSeparation();
@@ -488,7 +488,7 @@ For* Parser::parseFor()
 		getToken();
 		result->setUntilCondition(parseExpression());
 	}
-	else if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
+	else if(hasTokens() && peekToken().getType() == T_OD)
 		getToken();
 	else
 		throw ParserSyntaxException(getToken(), "Expected \"od\" or \"until\" command!");
@@ -908,14 +908,14 @@ Repeat* Parser::parseRepeat()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> stmts(new NodeList());
-	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL || peekToken().getType() == T_G_END))
+	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL))
 	{
 		stmts->pushNode(parseStatement());
 		parseSeparation();
 	}
 	result->setStatements(stmts.release());
 
-	if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
+	if(hasTokens() && peekToken().getType() == T_OD)
 		getToken();
 	else if(hasTokens() && peekToken().getType() == T_UNTIL)
 	{
@@ -1019,7 +1019,7 @@ While* Parser::parseWhile()
 
 	// Add commands until "od" or "until" is found
 	std::unique_ptr<NodeList> whileStmts(new NodeList());
-	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL || peekToken().getType() == T_G_END))
+	while(hasTokens() && !(peekToken().getType() == T_OD || peekToken().getType() == T_UNTIL))
 	{
 		whileStmts->pushNode(parseStatement());
 		parseSeparation();
@@ -1029,7 +1029,7 @@ While* Parser::parseWhile()
 	result->setLineNumber(tok.getLineNumber());
 	result->setColumnNumber(tok.getColumnNumber());
 
-	if(hasTokens() && (peekToken().getType() == T_OD || peekToken().getType() == T_G_END))
+	if(hasTokens() && peekToken().getType() == T_OD)
 	{
 		getToken();
 		result->setCondition(cond.release());


### PR DESCRIPTION
It was removed in 2016 in https://github.com/freeduke33/rerap2/commit/a837886c0751aa7707a1d89f198654f2e9e82e5e#diff-bde656ac968c9f22b7168e822d3b1071a173b926b173d6b45bde8db93ff2a9e4L134 -- probably by mistake.